### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,7 @@ StandardOutput=syslog
 StandardError=syslog
 SyslogIdentifier=flexfarmer
 Restart=on-failure
+RestartSec=30
 
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
Add "RestartSec=30" to service file, early fails(e.g. because of not loaded USB drives) would request to many restarts too quickly, service would refuse to start